### PR TITLE
Add changelog to CLI

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,4 +1,4 @@
-const CHANGELOG: &'static str = include_str!("../CHANGELOG.md");
+const CHANGELOG: &str = include_str!("../CHANGELOG.md");
 
 pub fn get_changelog() -> &'static str {
     CHANGELOG

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -3,3 +3,14 @@ const CHANGELOG: &str = include_str!("../CHANGELOG.md");
 pub fn get_changelog() -> &'static str {
     CHANGELOG
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_changelog() {
+        let changelog = get_changelog();
+        assert!(changelog.starts_with("# Changelog\n\n## v"));
+    }
+}

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -11,6 +11,16 @@ mod tests {
     #[test]
     fn test_changelog() {
         let changelog = get_changelog();
-        assert!(changelog.starts_with("# Changelog\n\n## v"));
+        for line in changelog.lines() {
+            assert!(
+                line == "# Changelog"
+                    || line.is_empty()
+                    || line.starts_with("## v")
+                    || line.starts_with("* ")
+                    || line == "Initial release:",
+                "Invalid line format: {}",
+                line
+            );
+        }
     }
 }

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,0 +1,5 @@
+const CHANGELOG: &'static str = include_str!("../CHANGELOG.md");
+
+pub fn get_changelog() -> &'static str {
+    CHANGELOG
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use rustyline::Editor;
 use fend_core::Context;
 use std::path::PathBuf;
 
+mod changelog;
 mod config;
 mod helper;
 mod interrupt;
@@ -59,6 +60,10 @@ fn print_help(explain_quitting: bool) {
     }
 }
 
+fn print_changelog() {
+    println!("{}", changelog::get_changelog());
+}
+
 fn print_version() {
     println!("fend v0.1.6 (2020-10-05)");
     println!("fend-core v{}", fend_core::get_extended_version());
@@ -100,6 +105,7 @@ fn repl_loop() -> i32 {
                 "help" | "?" => {
                     print_help(true);
                 }
+                "changelog" => print_changelog(),
                 "version" => print_version(),
                 line => {
                     interrupt.reset();
@@ -150,6 +156,10 @@ fn main() {
     if let Some(expr) = args.next() {
         if expr == "help" || expr == "--help" || expr == "-h" {
             print_help(false);
+            return;
+        }
+        if expr == "changelog" || expr == "--changelog" {
+            print_changelog();
             return;
         }
         if expr == "version" || expr == "--version" || expr == "-v" || expr == "-V" {


### PR DESCRIPTION
This adds `fend --changelog`, and an interactive `changelog` command to view the changelog.

```
> changelog
# Changelog

## v0.1.6 (2020-10-05)

* Support outputting mixed fractions (implicitly or via `to mixed_fraction`)
* Support unmatched parentheses (e.g. `2+3)*(1+2` is `15`)
* Support parsing of numbers with recurring digits (e.g. `0.(3)` is equal to `1/3`)
* Allow numbers that start with a decimal point, such as `.1`

## v0.1.5 (2020-09-29)

* Add support for lambda functions (e.g. `\x.x`)
* Change precedence of `to`, `as` and `->`
* Add live CLI output

...
```